### PR TITLE
Do not install requirements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r environments/requirements.txt
           pip install tox
       - name: Perform tests
         run: tox -e test


### PR DESCRIPTION
Those are handled within tox environment now.
No need to install them globally with pip