### PR TITLE
add manager support for caching in shared memory among processes

### DIFF
--- a/tests/cachers_test.py
+++ b/tests/cachers_test.py
@@ -7,6 +7,7 @@ import torchfunc
 from .datasets import ExampleDataset, ExampleTensorDataset
 from .utils import artificial_slowdown, index_is_sample, is_on_disk
 
+from multiprocessing import Process, Manager
 
 def test_pickle_cache_slowdown():
     with torchdata.cachers.Pickle(pathlib.Path("./disk")) as pickler:
@@ -39,15 +40,15 @@ def test_tensor_cache():
         for i in range(datapoints):
             assert is_on_disk(path, i, ".pt")
 
-
-def test_shared_memory():
+def test_memory_cache():
     dataset = (
         ExampleTensorDataset(1000)
         .map(lambda tensor: tensor * 2)
         .map(lambda tensor: tensor + tensor)
-        .cache(torchdata.cachers.SharedMemory())
+        .cache(torchdata.cachers.Memory())
     )
-    dataloader = torch.utils.data.DataLoader(dataset, num_workers=2, batch_size=10)
+
+    dataloader = torch.utils.data.DataLoader(dataset, num_workers=0, batch_size=10)
     with torchfunc.Timer() as timer:
         for _ in dataloader:
             pass
@@ -56,3 +57,63 @@ def test_shared_memory():
             pass
         cached_pass = timer.checkpoint()
         assert cached_pass < initial_pass
+
+
+
+def shared_subprocess(cache, refs):
+    cacher = torchdata.cachers.Memory(cache)
+
+    if id(cacher.cache) in refs.keys():
+        refs[id(cacher.cache)] += 1
+
+    dataset = (
+        ExampleTensorDataset(1000)
+        .map(lambda tensor: tensor * 2)
+        .map(lambda tensor: tensor + tensor)
+        .cache(cacher)
+    )
+    dataloader = torch.utils.data.DataLoader(dataset, num_workers=4, batch_size=10)
+    with torchfunc.Timer() as timer:
+        for _ in dataloader:
+            pass
+        initial_pass = timer.checkpoint()
+        for _ in dataloader:
+            pass
+        cached_pass = timer.checkpoint()
+        assert cached_pass < initial_pass
+
+    assert len(cacher.cache) > 0
+
+def test_shared_memory():
+    torch.multiprocessing.set_sharing_strategy('file_system')
+
+    manager = Manager()
+    cache = manager.dict()
+    refs = manager.dict()
+    refs[id(cache)] = 0
+
+    # Test speedup
+    shared_subprocess(cache, refs)
+
+    # Test shared cache with mp
+    shared_cache = Manager().dict()
+    del refs
+    refs = manager.dict()
+    refs[id(shared_cache)] = 0
+
+    # Simulate multiprocesses training (i.e. DDP)
+    procs = []
+    n_processes = 2
+    for i in range(n_processes):
+        p = Process(target=shared_subprocess, args=(shared_cache, refs))
+        p.start()
+        procs.append(p)
+
+    for p in procs:
+        p.join()
+
+    # Check if provided cache was used
+    assert len(shared_cache) > 0
+
+    # Check that all of the processes actually used the same cache
+    assert refs[id(shared_cache)] == n_processes

--- a/torchdata/cachers.py
+++ b/torchdata/cachers.py
@@ -15,10 +15,12 @@ are too slow or not good enough for their purposes (see `Cacher` abstract interf
 
 import abc
 import multiprocessing
+from multiprocessing import Manager
 import pathlib
 import pickle
 import shutil
 import typing
+from typing import Optional
 
 import torch
 
@@ -184,10 +186,17 @@ class Memory(Cacher):
 
     This `cacher` is used by default inside `torchdata.Dataset`.
 
+    Attributes
+    ----------
+    manager: multiprocessing.Manager
+            Optional, instance of multiprocessing.Manager
     """
 
-    def __init__(self):
-        self.cache = {}
+    def __init__(self, manager: Optional[Manager]=None):
+        if manager is None:
+            self.cache = {}
+        else:
+            self.cache = manager.dict()
 
     def __contains__(self, index: int) -> bool:
         """True if index in dictionary."""

--- a/torchdata/cachers.py
+++ b/torchdata/cachers.py
@@ -322,29 +322,3 @@ class Tensor(Cacher):
 
     def __exit__(self, *args):
         self.clean()
-
-
-class SharedMemory(Cacher):
-    r"""**Save and load data in shared dictionary between multiple processes **.
-
-    .. note::
-
-        This `cacher` should be used with `torch.utils.data.DataLoader` if
-        `num_workers` is greater than default `0`.
-
-    """
-
-    def __init__(self):
-        self.cache = multiprocessing.Manager().dict()
-
-    def __contains__(self, index: int) -> bool:
-        """True if index in dictionary."""
-        return index in self.cache
-
-    def __setitem__(self, index: int, data: int):
-        """Adds data to dictionary."""
-        self.cache[index] = data
-
-    def __getitem__(self, index: int):
-        """Retrieve data from dictionary."""
-        return self.cache[index]

--- a/torchdata/cachers.py
+++ b/torchdata/cachers.py
@@ -192,7 +192,9 @@ class Memory(Cacher):
     """
 
     def __init__(self, cache: Optional[dict]=None):
-        self.cache = cache or {}
+        self.cache = cache
+        if cache is None:
+            self.cache = {}
 
     def __contains__(self, index: int) -> bool:
         """True if index in dictionary."""

--- a/torchdata/cachers.py
+++ b/torchdata/cachers.py
@@ -15,7 +15,6 @@ are too slow or not good enough for their purposes (see `Cacher` abstract interf
 
 import abc
 import multiprocessing
-from multiprocessing import Manager
 import pathlib
 import pickle
 import shutil
@@ -188,15 +187,12 @@ class Memory(Cacher):
 
     Attributes
     ----------
-    manager: multiprocessing.Manager
-            Optional, instance of multiprocessing.Manager
+    cache: dict
+            Optional, user-provided caching dictionary (i.e. obtained with multiprocessing.Manager)
     """
 
-    def __init__(self, manager: Optional[Manager]=None):
-        if manager is None:
-            self.cache = {}
-        else:
-            self.cache = manager.dict()
+    def __init__(self, cache: Optional[dict]=None):
+        self.cache = cache or {}
 
     def __contains__(self, index: int) -> bool:
         """True if index in dictionary."""


### PR DESCRIPTION
Using a manager allows for data caching among different pytorch workers. It should also decrease the total amount of memory required (i.e. caching only once instead 1*n_workers). With this code i managed to decrease the epoch time when working on very large images from ~15 minutes to ~20 seconds.

If caching many items, i.e. the entire dataset, the following line may be necessary in order not to hit the file descriptors limit for the processes (ulimit) 


```
torch.multiprocessing.set_sharing_strategy('file_system')
```